### PR TITLE
Revert "Fix temporarily download.o.o outage"

### DIFF
--- a/tests/rspec_webui_tests.pm
+++ b/tests/rspec_webui_tests.pm
@@ -10,13 +10,6 @@ sub run() {
 
     assert_script_run("git clone --single-branch --branch $branch --depth 1 https://github.com/openSUSE/open-build-service.git  /tmp/open-build-service", 240);
     assert_script_run("cd /tmp/open-build-service/dist/t");
-    # download.o.o temporarily down
-    assert_script_run("mkdir /etc/zypp/repos.d/old");
-    assert_script_run("mv /etc/zypp/repos.d/*.repo /etc/zypp/repos.d/old");
-    assert_script_run("zypper ar -f -c https://ftp.gwdg.de/pub/opensuse/repositories/OBS:/Server:/Unstable/openSUSE_42.2/OBS:Server:Unstable.repo");
-    assert_script_run("sed -i 's|download.opensuse.org|ftp.gwdg.de/pub/opensuse|' /etc/zypp/repos.d/OBS_Server_Unstable.repo");
-    assert_script_run("zypper ref");
-    # download.o.o temporarily down
     assert_script_run("zypper -vv -n --gpg-auto-import-keys in --force-resolution --no-recommends phantomjs libxml2-devel libxslt-devel ruby2.4-devel", 600);
     assert_script_run("bundle.ruby2.4 install", 600);
     assert_script_run("set -o pipefail; bundle.ruby2.4 exec rspec --format documentation | tee /tmp/rspec_tests.txt", 600);


### PR DESCRIPTION
This reverts commit fad96e69d0cb13da653e186d2465cd47129a623f.

`libxml2-devel` is not included in Unstable.