### PR TITLE
Revert "Update dependencies for OBS 2.9"

### DIFF
--- a/tests/rspec_webui_tests.pm
+++ b/tests/rspec_webui_tests.pm
@@ -10,7 +10,7 @@ sub run() {
 
     assert_script_run("git clone --single-branch --branch $branch --depth 1 https://github.com/openSUSE/open-build-service.git  /tmp/open-build-service", 240);
     assert_script_run("cd /tmp/open-build-service/dist/t");
-    assert_script_run("zypper -vv -n --gpg-auto-import-keys in --force-resolution --no-recommends phantomjs libxml2-devel libxslt-devel ruby2.4-devel lsof", 600);
+    assert_script_run("zypper -vv -n --gpg-auto-import-keys in --force-resolution --no-recommends phantomjs libxml2-devel libxslt-devel ruby2.4-devel", 600);
     assert_script_run("bundle.ruby2.4 install", 600);
     assert_script_run("set -o pipefail; bundle.ruby2.4 exec rspec --format documentation | tee /tmp/rspec_tests.txt", 600);
     save_screenshot;


### PR DESCRIPTION
This reverts commit b53421b8b1723156be0bd5344a8ecfb72ef773ac.

Seems like lsof is not necessary, the issue was only caused by the not published repository