### PR TITLE
Set test default distribution

### DIFF
--- a/main.pm
+++ b/main.pm
@@ -17,7 +17,9 @@
 use strict;
 use testapi;
 use autotest;
+use distribution;
 
+testapi::set_distribution(distribution->new);
 autotest::loadtest "tests/boot.pm";
 autotest::loadtest "tests/rspec_webui_tests.pm";
 


### PR DESCRIPTION
Set up the test distribution to fix [poo#34522](https://progress.opensuse.org/issues/34522) from a test perspective

Proof run: http://phobos.suse.de/tests/10977