### PR TITLE
Replace phantomjs by chromedriver for smoke tests

### DIFF
--- a/tests/rspec_webui_tests.pm
+++ b/tests/rspec_webui_tests.pm
@@ -15,7 +15,7 @@ sub run() {
 
     assert_script_run("git clone --single-branch --branch $branch --depth 1 https://github.com/openSUSE/open-build-service.git  /tmp/open-build-service", 240);
     assert_script_run("cd /tmp/open-build-service/dist/t");
-    assert_script_run("zypper -vv -n --gpg-auto-import-keys in --force-resolution --no-recommends phantomjs libxml2-devel libxslt-devel ruby$ruby_version-devel", 600);
+    assert_script_run("zypper -vv -n --gpg-auto-import-keys in --force-resolution --no-recommends chromedriver libxml2-devel libxslt-devel ruby$ruby_version-devel", 600);
     assert_script_run("bundle.ruby$ruby_version install", 600);
     assert_script_run("set -o pipefail; bundle.ruby$ruby_version exec rspec --format documentation | tee /tmp/rspec_tests.txt", 600);
     save_screenshot;


### PR DESCRIPTION
OpenQA tests failed because phantomjs was not available in Unstable version.
We replace poltergeist (using phantomjs) by selenium and chromedriver as
web driver.

Co-authored-by: Eduardo Navarro <enavarro@suse.com>