### PR TITLE
Remove references to OBS 2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Currently we test:
 - [Unstable](https://build.opensuse.org/project/show/OBS:Server:Unstable)
 - [2.10:Staging](https://build.opensuse.org/project/show/OBS:Server:2.10:Staging)
 - [2.9:Staging](https://build.opensuse.org/project/show/OBS:Server:2.9:Staging)
-- [2.8:Staging](https://build.opensuse.org/project/show/OBS:Server:2.8:Staging)
 
 The test consists basically on booting the appliance and running an [RSpec smoketest](https://github.com/openSUSE/open-build-service/tree/master/dist/t/spec).
 Every new appliance gets tested on the [openSUSE reference installation](https://openqa.opensuse.org/parent_group_overview/7).

--- a/tests/rspec_webui_tests.pm
+++ b/tests/rspec_webui_tests.pm
@@ -11,9 +11,6 @@ sub run() {
     }
 
     my $ruby_version = "2.5";
-    if (get_var('VERSION') == "2.8") {
-        $ruby_version = "2.4";
-    }
 
     assert_script_run("git clone --single-branch --branch $branch --depth 1 https://github.com/openSUSE/open-build-service.git  /tmp/open-build-service", 240);
     assert_script_run("cd /tmp/open-build-service/dist/t");


### PR DESCRIPTION
OBS 2.8 is not tested in openQA any more.