### PR TITLE
Increase timeout for check_required_services

### DIFF
--- a/tests/rspec_webui_tests.pm
+++ b/tests/rspec_webui_tests.pm
@@ -15,7 +15,7 @@ sub run() {
     assert_script_run("zypper -vv -n --gpg-auto-import-keys in --force-resolution --no-recommends $tests_packages libxml2-devel libxslt-devel ruby$ruby_version-devel", 600);
     assert_script_run("git clone --single-branch --branch $branch --depth 1 https://github.com/openSUSE/open-build-service.git /tmp/open-build-service", 240);
     assert_script_run("cd /tmp/open-build-service/dist/t");
-    assert_script_run("set -o pipefail; prove -v *-check_required_services.ts | tee /tmp/check_required_services_tests.txt");
+    assert_script_run("set -o pipefail; prove -v *-check_required_services.ts | tee /tmp/check_required_services_tests.txt", 300);
     assert_script_run("bundle.ruby$ruby_version install", 600);
     assert_script_run("set -o pipefail; bundle.ruby$ruby_version exec rspec --format documentation | tee /tmp/rspec_tests.txt", 600);
     save_screenshot;


### PR DESCRIPTION
The default timeout of `assert_script_run` is 90 seconds. Apache2 will not be started until `setup-appliance.sh` finishes to start all other OBS services. Increasing this timeout to 300 will most probably fix the timeout issues found in openQA tests.